### PR TITLE
Makefile: Allow build debug binary without Address Sanitizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,15 @@ OBJS+=parser.yy.o parser.tab.o
 
 all: $(PROG)
 
-debug: CFLAGS+=-g -DDEBUG -fsanitize=address
-debug: LDFLAGS:=-lasan $(LDFLAGS)
+debug: CFLAGS+=-g -DDEBUG
+debug: LDFLAGS:=$(LDFLAGS)
 debug: FLEXFLAGS+=-d
 debug: $(PROG)
+
+asan-debug: CFLAGS+=-g -DDEBUG -fsanitize=address
+asan-debug: LDFLAGS:=-lasan $(LDFLAGS)
+asan-debug: FLEXFLAGS+=-d
+asan-debug: $(PROG)
 
 asan: CFLAGS+=-fsanitize=address
 asan: LDFLAGS:=-lasan $(LDFLAGS)


### PR DESCRIPTION
Default build do not enable Address Sanitizer, however default debug
build enables it. With this patch, default debug build will also disable
Address Sanitizer and if user want to make a debug build with Address
Sanitizer enabled, user can `make asan-debug`.

Signed-off-by: Ziqian SUN <zsun@redhat.com>