### PR TITLE
Makefile: Honor CFLAGS and LDFLAGS from commandline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ PROG=kabi-dw
 SRCS=generate.c ksymtab.c utils.c main.c stack.c objects.c hash.c
 SRCS += compare.c show.c
 
-CC=gcc
-CFLAGS=-Wall -O2 --std=gnu99 -D_GNU_SOURCE -c
-LDFLAGS=-ldw -lelf
+CC?=gcc
+CFLAGS?=-Wall -O2 --std=gnu99 -D_GNU_SOURCE -c
+LDFLAGS?=-ldw -lelf
 
 YACC=bison
 YACCFLAGS=-d -t
@@ -31,6 +31,22 @@ OBJS=$(SRCS:.c=.o)
 OBJS+=parser.yy.o parser.tab.o
 
 .PHONY: clean all depend debug asan
+
+ifeq (,$(findstring -c,$(CFLAGS)))
+override CFLAGS+=-c
+endif
+
+ifeq (,$(findstring -D_GNU_SOURCE,$(CFLAGS)))
+override CFLAGS+=-D_GNU_SOURCE
+endif
+
+ifeq (,$(findstring -ldw,$(LDFLAGS)))
+override LDFLAGS+=-ldw
+endif
+
+ifeq (,$(findstring -lelf,$(LDFLAGS)))
+override LDFLAGS+=-lelf
+endif
 
 all: $(PROG)
 


### PR DESCRIPTION
CFLAGS and LDFLAGS are set with fixed values in Makefile. This will be a
problem for packaging when distribution has special requirements for
flags. With this patch, Makefile accepts CFLAGS and LDFLAGS from
commandline, detecting essential flags before build time.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1543803

Signed-off-by: Zamir SUN <sztsian@gmail.com>