### PR TITLE
parser.l: Fix regex for built-in file path matching

### DIFF
--- a/parser.l
+++ b/parser.l
@@ -64,7 +64,7 @@ HEX		[a-fA-F0-9]
 
 "->"	{ return(ARROW); }
 
-{FILECHAR}+"."[chS]|"<built-in>"	{ yylval.str = strdup(yytext);
+{FILECHAR}+("."[chS]|"<built-in>")	{ yylval.str = strdup(yytext);
 				  debug("Source file: %s\n", yylval.str);
 				  return(SRCFILE);
 				}


### PR DESCRIPTION
Fixes: RHBZ 1642806
https://bugzilla.redhat.com/show_bug.cgi?id=1642806

Signed-off-by: Zamir SUN <sztsian@gmail.com>