### PR TITLE
generate: fix is_external() to handle DW_FORM_flag

### DIFF
--- a/generate.c
+++ b/generate.c
@@ -382,6 +382,8 @@ static int is_external(Dwarf_Die *die)
 
 	if (dwarf_hasattr(die, DW_AT_external)) {
 		dwarf_attr(die, DW_AT_external, &attr);
+		if (dwarf_hasform(&attr, DW_FORM_flag))
+			return attr.valp != NULL;
 		if (!dwarf_hasform(&attr, DW_FORM_flag_present))
 			return false;
 		return true;


### PR DESCRIPTION
According to DWARFv5 section 7.5.5 on page 215, the flag is represented
either explicitly as DW_FORM_flag or implicitly as DW_FORM_flag_present.
In the first case, the value dictates the presence of the attribute.

Signed-off-by: Xiao Jia <xiaoj@google.com>