### PR TITLE
objects: add bytesize comparison to obj_eq

### DIFF
--- a/objects.c
+++ b/objects.c
@@ -1023,7 +1023,8 @@ static bool obj_eq(obj_t *o1, obj_t *o2)
 	    (has_constant(o1) && (o1->constant != o2->constant)) ||
 	    (has_index(o1) && (o1->index != o2->index)) ||
 	    (is_bitfield(o1) != is_bitfield(o2)) ||
-	    (o1->alignment != o2->alignment))
+	    (o1->alignment != o2->alignment) ||
+	    (o1->byte_size != o2->byte_size))
 		return false;
 
 	/* just compare bitfields */


### PR DESCRIPTION
`obj_eq` does not perform a complete check of object equality. Consider:

 - structure packing

   two modules using a common header, exactly one built with `-fpack-struct`,
   or two modules built against an different versions of an external header
   file overtime, with exactly one explicitly using `__attribute__((packed))`

 - enum optimizations

   two modules using a common header, exactly one built with `-fshort-enums`

In cases such as these, bytesize entry will be emitted correctly for each
of these modules separately, however, when ran on both at the same time,
the missing `obj_eq` check causes the conflicting records to be merged.

Signed-off-by: Čestmír Kalina <ckalina@redhat.com>