### PR TITLE
generate: decrease amount of generated records

### DIFF
--- a/compare.c
+++ b/compare.c
@@ -115,7 +115,8 @@ typedef enum {
 	CMP_BYTE_SIZE,  /* Byte size has changed */
 } cmp_ret_t;
 
-static int compare_two_files(char *filename, char *newfile, bool follow);
+static int compare_two_files(const char *filename, const char *newfile,
+			     bool follow);
 
 static int cmp_node_reffile(obj_t *o1, obj_t *o2)
 {
@@ -490,7 +491,7 @@ static int compare_tree(obj_t *o1, obj_t *o2, FILE *stream)
 	return _compare_tree(o1, o2, stream);
 }
 
-static bool push_file(char *filename)
+static bool push_file(const char *filename)
 {
 	int i, sz = compare_config.flistsz;
 	int cnt = compare_config.flistcnt;
@@ -572,12 +573,14 @@ static void compare_usage()
  *           don't print anything and exit immediately if follow
  *           option isn't set.
  */
-static int compare_two_files(char *filename, char *newfile, bool follow)
+static int compare_two_files(const char *filename, const char *newfile,
+			     bool follow)
 {
 	obj_t *root1, *root2;
 	char *old_dir = compare_config.old_dir;
 	char *new_dir = compare_config.new_dir;
-	char *path1, *path2, *s = NULL, *filename2;
+	char *path1, *path2, *s = NULL;
+	const char *filename2;
 	FILE *file1, *file2, *stream;
 	struct stat fstat;
 	size_t sz;

--- a/generate.c
+++ b/generate.c
@@ -49,6 +49,7 @@
 #include "hash.h"
 #include "objects.h"
 #include "list.h"
+#include "record.h"
 
 #define	EMPTY_NAME	"(NULL)"
 #define PROCESSED_SIZE 1024
@@ -66,8 +67,6 @@
 #ifndef DW_AT_alignment
 #define DW_AT_alignment 0x88
 #endif
-
-#define RECORD_VERSION_DECLARATION -1
 
 struct set;
 struct record_db;
@@ -114,71 +113,6 @@ struct dwarf_type {
 	{ 0, NULL }
 };
 
-
-/*
- * Structure of the database record:
- *
- * key: record key, usually includes path the file, where the type is
- *      defined (may include pseudo path, like <declaration>);
- *
- * version: type's version, used when we need to add another type of the same
- *	    name. It may happend, for example, when because of defines the same
- *          structure has changed for different compilation units.
- *
- *          It is not for the case, when the same structure defined in
- *	    different files -- it will have different keys, since it includes
- *	    the path;
- *
- * ref_count: reference counter, needed since the ownership is shared with the
- *            internal database;
- *
- * base_file: base part of the key (without version), used to generate the
- *            unique key for the new version;
- *
- * cu: compilation unit, where the type for the record defined;
- *
- * origin: "File <file>:<line>" string, describing the source, where the type
- *         for the record defined;
- *
- * stack: stack of types to reach this one.
- *         Ex.: on the toplevel
- *              struct A {
- *                        struct B fieldA;
- *              }
- *         in another file:
- *              struct B {
- *                        basetype fieldB;
- *              }
- *         the "struct B" description will contain key of the "struct A"
- *         description record in the stack;
- *
- * obj: pointer to the abstract type object, representing the toplevel type of
- *      the record.
- *
- * link: name of weak link alisas for the weak aliases.
- *
- * free: type specific function to free the record
- *       (there are normal, weak and assembly records).
- *
- * dump: type specific function for record output.
- *
- * dependents: objects that reference this record.
- */
-struct record {
-	char *key;
-	int version;
-	int ref_count;
-	char *base_file;
-	char *cu;
-	char *origin;
-	stack_t *stack;
-	obj_t *obj;
-	char *link;
-	void (*free)(struct record *);
-	void (*dump)(struct record *, FILE *);
-
-	struct list dependents;
-};
 
 void record_update_dependents(struct record *record)
 {

--- a/generate.c
+++ b/generate.c
@@ -1065,7 +1065,7 @@ static char *record_db_add(struct record_db *db, struct record *rec)
 	record_get(rec);
 	record_set_version(rec, records_amount);
 	record_redirect_dependents(rec, rec);
-	list_add(record_list_records(rec_list), rec);
+	rec->list_node = list_add(record_list_records(rec_list), rec);
 
 	return safe_strdup(rec->key);
 }

--- a/generate.c
+++ b/generate.c
@@ -920,7 +920,7 @@ static void list_record_free(void *value)
  */
 static bool record_merge(struct record *rec_dst,
 			 struct record *rec_src,
-			 bool merge_decl)
+			 unsigned int flags)
 {
 	const char *s1;
 	const char *s2;
@@ -937,7 +937,7 @@ static bool record_merge(struct record *rec_dst,
 	o1 = record_obj(rec_dst);
 	o2 = record_obj(rec_src);
 
-	o = obj_merge(o1, o2, merge_decl);
+	o = obj_merge(o1, o2, flags);
 	if (o == NULL)
 		return false;
 
@@ -1053,7 +1053,7 @@ static char *record_db_add(struct record_db *db, struct record *rec)
 	LIST_FOR_EACH(record_list_records(rec_list), iter) {
 		tmp_rec = list_node_data(iter);
 
-		if (record_merge(tmp_rec, rec, NO_MERGE_DECL)) {
+		if (record_merge(tmp_rec, rec, MERGE_DEFAULT)) {
 			record_redirect_dependents(tmp_rec, rec);
 			list_concat(&tmp_rec->dependents, &rec->dependents);
 			return safe_strdup(tmp_rec->key);
@@ -2021,7 +2021,7 @@ struct record *record_copy(struct record *src)
 	struct record *res = record_new_regular("");
 	obj_t *o1 = record_obj(src);
 
-	res->obj = obj_merge(o1, o1, MERGE_DECL);
+	res->obj = obj_merge(o1, o1, MERGE_FLAG_DECL_MERGE);
 	obj_fill_parent(res->obj);
 	res->origin = safe_strdup(src->origin);
 	res->base_file = NULL;
@@ -2044,7 +2044,8 @@ bool record_list_can_merge(struct list *rec_list)
 	LIST_FOR_EACH(rec_list, iter) {
 		struct record *record = list_node_data(iter);
 
-		if (!record_merge(merger, record, MERGE_DECL)) {
+		if (!record_merge(merger, record,
+				  MERGE_FLAG_DECL_MERGE)) {
 			result = false;
 			break;
 		}
@@ -2069,7 +2070,7 @@ void record_list_merge(struct list *rec_list)
 		record = curr->data;
 
 		list_concat(&first->dependents, &record->dependents);
-		record_merge(first, record, MERGE_DECL);
+		record_merge(first, record, MERGE_FLAG_DECL_MERGE);
 		record_put(record);
 
 		free(curr);

--- a/main.c
+++ b/main.c
@@ -33,6 +33,7 @@
 #include "generate.h"
 #include "compare.h"
 #include "show.h"
+#include "utils.h"
 
 static char *progname;
 
@@ -57,6 +58,8 @@ int main(int argc, char **argv)
 
 	argv++; argc--;
 
+	global_string_keeper_init();
+
 	if (strcmp(argv[0], "generate") == 0)
 		generate(argc, argv);
 	else if (strcmp(argv[0], "compare") == 0)
@@ -65,6 +68,8 @@ int main(int argc, char **argv)
 		ret = show(argc, argv);
 	else
 		usage();
+
+	global_string_keeper_free();
 
 	return ret;
 }

--- a/objects.c
+++ b/objects.c
@@ -1190,7 +1190,12 @@ no_merge:
 
 static void dump_reffile(obj_t *o, FILE *f)
 {
-	fprintf(f, "@\"%s\"\n", record_get_key(o->ref_record));
+	int version = record_get_version(o->ref_record);
+
+	fprintf(f, "@\"%s", record_get_key(o->ref_record));
+	if (version > 0)
+		fprintf(f, "-%i", version);
+	fprintf(f, ".txt\"\n");
 }
 
 static void _dump_members(obj_t *o, FILE *f, void (*dumper)(obj_t *, FILE *))

--- a/objects.h
+++ b/objects.h
@@ -33,8 +33,12 @@
 #define debug(args...)
 #endif
 
-#define MERGE_DECL true
-#define NO_MERGE_DECL false
+enum merge_flag {
+	MERGE_DEFAULT = 0,
+	MERGE_FLAG_DECL_MERGE = 1 << 0,
+	MERGE_FLAG_VER_IGNORE = 1 << 1,
+	MERGE_FLAG_DECL_EQ = 1 << 2,
+};
 
 typedef enum {
 	__type_reffile,
@@ -235,7 +239,7 @@ int obj_walk_tree3(obj_t *o, cb_t cb_pre, cb_t cb_in, cb_t cb_post,
 int obj_hide_kabi(obj_t *root, bool show_new_field);
 
 obj_t *obj_parse(FILE *file, char *fn);
-obj_t *obj_merge(obj_t *o1, obj_t *o2, bool merge_decl);
+obj_t *obj_merge(obj_t *o1, obj_t *o2, unsigned int flags);
 void obj_dump(obj_t *o, FILE *f);
 
 #endif

--- a/objects.h
+++ b/objects.h
@@ -26,6 +26,7 @@
 #include <stdio.h>
 
 #include "list.h"
+#include "utils.h"
 
 #ifdef DEBUG
 #define debug(args...) do { printf(args); } while (0)
@@ -102,8 +103,8 @@ typedef struct obj_list_head {
  */
 typedef struct obj {
 	obj_types type;
-	char *name;
-	char *base_type;
+	const char *name;
+	const char *base_type;
 	unsigned alignment;
 	unsigned int byte_size;
 	obj_list_head_t *member_list;

--- a/objects.h
+++ b/objects.h
@@ -34,6 +34,8 @@
 #define debug(args...)
 #endif
 
+struct set;
+
 enum merge_flag {
 	MERGE_DEFAULT = 0,
 	MERGE_FLAG_DECL_MERGE = 1 << 0,
@@ -242,5 +244,9 @@ int obj_hide_kabi(obj_t *root, bool show_new_field);
 obj_t *obj_parse(FILE *file, char *fn);
 obj_t *obj_merge(obj_t *o1, obj_t *o2, unsigned int flags);
 void obj_dump(obj_t *o, FILE *f);
+
+bool obj_eq(obj_t *o1, obj_t *o2, bool ignore_versions);
+
+bool obj_same_declarations(obj_t *o1, obj_t *o2, struct set *processed);
 
 #endif

--- a/objects.h
+++ b/objects.h
@@ -90,6 +90,8 @@ typedef struct obj_list_head {
  * first_bit, last_bit: (var) bit range within the offset.
  * depend_rec_node:	(reffile) node from dependents field of record where
  *			this obj references.
+ * ref_record:	(reffile) pointer to the referenced record (only while
+ *              generating records, otherwise base_type with string is used)
  *
  * Note the dual parent/child relationship with the n-ary member_list and the
  * the unary ptr. Only functions uses both.
@@ -112,6 +114,8 @@ typedef struct obj {
 		};
 		struct list_node *depend_rec_node;
 	};
+
+	struct record *ref_record;
 } obj_t;
 
 static inline bool has_offset(obj_t *o)

--- a/objects.h
+++ b/objects.h
@@ -78,7 +78,11 @@ typedef struct obj_list_head {
  *
  * type:	type of the symbol (such as struct, function, pointer, base
  *		type...)
+ * is_bitfield:	(var) It's a bitfield
+ * first_bit, last_bit:	(var) bit range within the offset.
  * name:	name of the symbol
+ * ref_record:	(reffile) pointer to the referenced record (only while
+ *              generating records, otherwise base_type with string is used)
  * base_type:	(base type) the type of the symbol,
  *		(qualifier) the type qualifier (const or volatile)
  *		(reffile) path to the file
@@ -93,19 +97,19 @@ typedef struct obj_list_head {
  * index:	(array) index of array
  * link:	(weak) weak alias link
  * offset:	(var) offset of a struct member
- * is_bitfield: (var) It's a bitfield
- * first_bit, last_bit: (var) bit range within the offset.
  * depend_rec_node:	(reffile) node from dependents field of record where
  *			this obj references.
- * ref_record:	(reffile) pointer to the referenced record (only while
- *              generating records, otherwise base_type with string is used)
  *
  * Note the dual parent/child relationship with the n-ary member_list and the
  * the unary ptr. Only functions uses both.
  */
 typedef struct obj {
 	obj_types type;
-	const char *name;
+	unsigned char is_bitfield, first_bit, last_bit;
+	union {
+		const char *name;
+		struct record *ref_record;
+	};
 	const char *base_type;
 	unsigned alignment;
 	unsigned int byte_size;
@@ -115,14 +119,9 @@ typedef struct obj {
 		unsigned long constant;
 		unsigned long index;
 		char *link;
-		struct {
-			unsigned long offset;
-			unsigned char is_bitfield, first_bit, last_bit;
-		};
+		unsigned long offset;
 		struct list_node *depend_rec_node;
 	};
-
-	struct record *ref_record;
 } obj_t;
 
 static inline bool has_offset(obj_t *o)

--- a/record.h
+++ b/record.h
@@ -15,6 +15,7 @@
  *
  * key: record key, usually includes path the file, where the type is
  *      defined (may include pseudo path, like <declaration>);
+ *      Does not contain version and the .txt suffix.
  *
  * version: type's version, used when we need to add another type of the same
  *	    name. It may happend, for example, when because of defines the same
@@ -26,9 +27,6 @@
  *
  * ref_count: reference counter, needed since the ownership is shared with the
  *            internal database;
- *
- * base_file: base part of the key (without version), used to generate the
- *            unique key for the new version;
  *
  * cu: compilation unit, where the type for the record defined;
  *
@@ -66,7 +64,6 @@ struct record {
 	char *key;
 	int version;
 	int ref_count;
-	char *base_file;
 	char *cu;
 	char *origin;
 	stack_t *stack;

--- a/record.h
+++ b/record.h
@@ -1,0 +1,93 @@
+#ifndef RECORD_H_
+#define RECORD_H_
+
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "list.h"
+#include "stack.h"
+#include "objects.h"
+
+#define RECORD_VERSION_DECLARATION -1
+
+/*
+ * Structure of the database record:
+ *
+ * key: record key, usually includes path the file, where the type is
+ *      defined (may include pseudo path, like <declaration>);
+ *
+ * version: type's version, used when we need to add another type of the same
+ *	    name. It may happend, for example, when because of defines the same
+ *          structure has changed for different compilation units.
+ *
+ *          It is not for the case, when the same structure defined in
+ *	    different files -- it will have different keys, since it includes
+ *	    the path;
+ *
+ * ref_count: reference counter, needed since the ownership is shared with the
+ *            internal database;
+ *
+ * base_file: base part of the key (without version), used to generate the
+ *            unique key for the new version;
+ *
+ * cu: compilation unit, where the type for the record defined;
+ *
+ * origin: "File <file>:<line>" string, describing the source, where the type
+ *         for the record defined;
+ *
+ * stack: stack of types to reach this one.
+ *         Ex.: on the toplevel
+ *              struct A {
+ *                        struct B fieldA;
+ *              }
+ *         in another file:
+ *              struct B {
+ *                        basetype fieldB;
+ *              }
+ *         the "struct B" description will contain key of the "struct A"
+ *         description record in the stack;
+ *
+ * obj: pointer to the abstract type object, representing the toplevel type of
+ *      the record.
+ *
+ * link: name of weak link alisas for the weak aliases.
+ *
+ * free: type specific function to free the record
+ *       (there are normal, weak and assembly records).
+ *
+ * dump: type specific function for record output.
+ *
+ * dependents: objects that reference this record.
+ */
+struct record {
+	char *key;
+	int version;
+	int ref_count;
+	char *base_file;
+	char *cu;
+	char *origin;
+	stack_t *stack;
+	obj_t *obj;
+	char *link;
+	void (*free)(struct record *);
+	void (*dump)(struct record *, FILE *);
+
+	struct list dependents;
+};
+
+static inline char *record_get_key(struct record *record)
+{
+	return record->key;
+}
+
+static inline int record_get_version(struct record *record)
+{
+	return record->version;
+}
+
+static inline bool record_is_declaration(struct record *record)
+{
+	return record->version == RECORD_VERSION_DECLARATION;
+}
+
+#endif /* RECORD_H_ */

--- a/record.h
+++ b/record.h
@@ -59,6 +59,8 @@
  *
  * list_node: node containing the record, record only belong to one list
  *            at a time(usually record_list.records)
+ *
+ * failed: number of times the record could not be used for merging
  */
 struct record {
 	const char *key;
@@ -74,6 +76,7 @@ struct record {
 
 	struct list dependents;
 	struct list_node *list_node;
+	unsigned int failed;
 };
 
 static inline const char *record_get_key(struct record *record)

--- a/record.h
+++ b/record.h
@@ -61,11 +61,11 @@
  *            at a time(usually record_list.records)
  */
 struct record {
-	char *key;
+	const char *key;
 	int version;
 	int ref_count;
 	char *cu;
-	char *origin;
+	const char *origin;
 	stack_t *stack;
 	obj_t *obj;
 	char *link;
@@ -76,7 +76,7 @@ struct record {
 	struct list_node *list_node;
 };
 
-static inline char *record_get_key(struct record *record)
+static inline const char *record_get_key(struct record *record)
 {
 	return record->key;
 }

--- a/record.h
+++ b/record.h
@@ -91,4 +91,7 @@ static inline bool record_is_declaration(struct record *record)
 	return record->version == RECORD_VERSION_DECLARATION;
 }
 
+bool record_same_declarations(struct record *r1, struct record *r2,
+			      struct set *processed);
+
 #endif /* RECORD_H_ */

--- a/record.h
+++ b/record.h
@@ -58,6 +58,9 @@
  * dump: type specific function for record output.
  *
  * dependents: objects that reference this record.
+ *
+ * list_node: node containing the record, record only belong to one list
+ *            at a time(usually record_list.records)
  */
 struct record {
 	char *key;
@@ -73,6 +76,7 @@ struct record {
 	void (*dump)(struct record *, FILE *);
 
 	struct list dependents;
+	struct list_node *list_node;
 };
 
 static inline char *record_get_key(struct record *record)

--- a/utils.h
+++ b/utils.h
@@ -152,7 +152,12 @@ extern int check_is_directory(char *);
 extern void rec_mkdir(char *);
 extern void safe_rename(const char *, const char *);
 extern char *path_normalize(char *);
-extern char *filenametotype(char *);
-extern char *filenametosymbol(char *);
+extern char *filenametotype(const char *);
+extern char *filenametosymbol(const char *);
+
+extern void global_string_keeper_init(void);
+extern void global_string_keeper_free(void);
+extern const char *global_string_get_copy(const char *string);
+extern const char *global_string_get_move(char *string);
 
 #endif /* UTILS_H */


### PR DESCRIPTION
This patch set aims to decrease the size of output. In doing so, the referencing strings no longer default to versions-less type after finding duplicate through the processed set. Instead with this patchset reference strings use the correct version and so it is possible to follow record tree with an arbitrary start (before it would be possible only if a starting point in a cu and order of processing of the records was known).

Decreasing of the size of output is accomplished by merging not single records but entire record trees.

While still loading new debug information, pair of record trees is merged if every pair of records contained within it meets merging conditions (conditions are the same as with older merging, but versions are ignored (since we also compare the referenced record) and the declarations need to be at the same positions (in order not to give potentially false information)).

After all debug information is loaded, records trees are divided into groups as small as possible (by using information obtained from the root record, without following reffile `obj_t`s). Every group then tries to merge into one tree by using aforementioned conditions with the difference that we now merge declarations.

There are also introduced some optimizations in order to increase the speed of processing and decrease the memory usage (e.g. reordering members of `obj_t`, usage of `global_string`s or skipping certain records while merging).

For examples of performance and output size changes see following table:

<table border="0" rules="groups" frame="hsides">
    <colgroup>
	<col  align="left" />
	<col  align="left" />
	<col  align="right" />
	<col  align="right" />
	<col  align="right" />
	<col  align="right" />
    </colgroup>
    <tbody>
	<tr>
	    <th scope="col" align="left">kernel version<br>( + whitelist)</th>
	    <th scope="col" align="left">kabi-dw<br>version</th>
	    <th scope="col" align="right">time<br>(s)</th>
	    <th scope="col" align="right">peak memory<br>(MB)</th>
	    <th scope="col" align="right">output size<br>(MB)</th>
	    <th scope="col" align="right">output<br>files #</th>
	</tr>
	<tr>
	    <td align="left">3.10.0-954.el7 (yes)</td>
	    <td align="left">older</td>
	    <td align="right">5.02</td>
	    <td align="right">174</td>
	    <td align="right">9.0</td>
	    <td align="right">2236</td>
	</tr>
	<tr>
	    <td align="left">&#xa0;</td>
	    <td align="left">before</td>
	    <td align="right">9.10</td>
	    <td align="right">229</td>
	    <td align="right">25.0</td>
	    <td align="right">5784</td>
	</tr>
    </tbody>
    <tbody>
	<tr>
	    <td align="left">&#xa0;</td>
	    <td align="left">after</td>
	    <td align="right">16.71</td>
	    <td align="right">317</td>
	    <td align="right">9.0</td>
	    <td align="right">2236</td>
	</tr>
	<tr>
	    <td align="left">3.10.0-954.el7 (no)</td>
	    <td align="left">older</td>
	    <td align="right">112</td>
	    <td align="right">225</td>
	    <td align="right">103</td>
	    <td align="right">25779</td>
	</tr>
	<tr>
	    <td align="left">&#xa0;</td>
	    <td align="left">before</td>
	    <td align="right">581</td>
	    <td align="right">497</td>
	    <td align="right">227</td>
	    <td align="right">54220</td>
	</tr>
    </tbody>
    <tbody>
	<tr>
	    <td align="left">&#xa0;</td>
	    <td align="left">after</td>
	    <td align="right">543</td>
	    <td align="right">1597</td>
	    <td align="right">103</td>
	    <td align="right">25702</td>
	</tr>
	<tr>
	    <td align="left">3.10.0-721.el7 (no)</td>
	    <td align="left">older</td>
	    <td align="right">90</td>
	    <td align="right">198</td>
	    <td align="right">97</td>
	    <td align="right">24279</td>
	</tr>
	<tr>
	    <td align="left">&#xa0;</td>
	    <td align="left">before</td>
	    <td align="right">416</td>
	    <td align="right">427</td>
	    <td align="right">194</td>
	    <td align="right">46276</td>
	</tr>
    </tbody>
    <tbody>
	<tr>
	    <td align="left">&#xa0;</td>
	    <td align="left">after</td>
	    <td align="right">440</td>
	    <td align="right">1333</td>
	    <td align="right">97</td>
	    <td align="right">24206</td>
	</tr>
    </tbody>
</table>



<table border="0" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">
<colgroup>
<col  class="org-left" />
<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-left">older</td>
<td class="org-left">8133076f87560d6e4bee875dae6ef16c46ebf1bb</td>
</tr>
<tr>
<td class="org-left">before</td>
<td class="org-left">8cd387a0f572145a7845b9bf942f6f418898b7fd</td>
</tr>
<tr>
<td class="org-left">after</td>
<td class="org-left">applied patchset</td>
</tr>
</tbody>
</table>





Even though generation takes more time and memory consumption is higher, output is smaller by half compared to current kabi-dw, and compared to commit 8133076 there is the same amount or less (due to cycle solving).

This patchset also prepares the ground for comparing of two outputs with functionality similar to what the `--follow` option offers, with the difference being that now it is okay if versions change due to order of their processing being changed. Only problem left is finding correct root record for comparing, which can be possibly solved similarly to how the record groups in patch 12 are being created.
