### PR TITLE
Add support for multiple stablelist headers, update to current terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ printk
 EOF
 ~~~
 
-Generate the type information for both kernels based on the current whitelist
+Generate the type information for both kernels based on the current stablelist
 
 ~~~
 ./kabi-dw generate -s symbols -o kabi-4.5 /usr/lib/modules/4.5.0

--- a/generate.c
+++ b/generate.c
@@ -1918,7 +1918,7 @@ static bool is_symbol_valid(struct file_ctx *fctx, Dwarf_Die *die)
 	struct ksym *ksym1 = NULL;
 	struct ksym *ksym2;
 
-	/* Shortcut, unnamed die cannot be part of whitelist */
+	/* Shortcut, unnamed die cannot be part of stablelist */
 	if (name == NULL)
 		goto out;
 
@@ -1949,7 +1949,7 @@ static bool is_symbol_valid(struct file_ctx *fctx, Dwarf_Die *die)
 	if (!is_external(die))
 		goto out;
 
-	/* We expect only variables or functions on whitelist */
+	/* We expect only variables or functions on stablelist */
 	switch (tag) {
 	case (DW_TAG_subprogram):
 		/*
@@ -2590,7 +2590,7 @@ static void strip(char *buf)
 
 /*
  * Check if the string is valid C identifier.
- * We do this so we can easily provide the standard kabi whitelist file as the
+ * We do this so we can easily provide the standard kabi stablelist file as the
  * symbol list.
  */
 static bool is_valid_c_identifier(char *s)
@@ -2697,7 +2697,7 @@ static void generate_usage()
 	       "    -o, --output kabi_dir:\n\t\t\t"
 	       "where to write kabi files (default: \"output\")\n"
 	       "    -s, --symbols symbol_file:\n\t\t\ta file containing the"
-	       " list of symbols of interest (e.g. whitelisted)\n"
+	       " list of symbols of interest (e.g. stablelisted)\n"
 	       "    -r, --rhel:\n\t\t\trun on the RHEL build tree\n"
 	       "    -a, --abs-path abs_path:\n\t\t\t"
 	       "replace the absolute path by a relative path\n"

--- a/generate.c
+++ b/generate.c
@@ -2616,23 +2616,34 @@ static bool is_valid_c_identifier(char *s)
 
 static bool is_kabi_header(char *s)
 {
-	const char *suffix = "_whitelist]";
-	int suffixlen = strlen(suffix);
+	const char *suffixes[2] = {
+		"_whitelist]",
+		"_stablelist]"
+	};
+
+	int suffixlen;
 	int len;
+	size_t i;
 
 	assert(s != NULL);
-
 	len = strlen(s);
-	if (len <= suffixlen + 1)
-		return false;
 
-	if (s[0] != '[')
-		return false;
+	for (i = 0; i < sizeof(suffixes)/sizeof(suffixes[0]); ++i) {
+		suffixlen = strlen(suffixes[i]);
 
-	if (strcmp(s + (len - suffixlen), suffix) != 0)
-		return false;
+		if (len <= suffixlen + 1)
+			continue;
 
-	return true;
+		if (s[0] != '[')
+			continue;
+
+		if (strcmp(s + (len - suffixlen), suffixes[i]) != 0)
+			continue;
+
+		return true;
+	}
+
+	return false;
 }
 
 /* Get list of symbols to generate. */

--- a/ksymtab.c
+++ b/ksymtab.c
@@ -505,7 +505,7 @@ static struct ksymtab *ksymtab_find_aliases(struct ksymtab *ksymtab,
 	ctx.weaks = weaks;
 	ctx.map = map;
 	/*
-	 * If there's a weak symbol on the whitelist,
+	 * If there's a weak symbol on the stablelist,
 	 * we need to find the proper global
 	 * symbol to generate the type for it.
 	 *


### PR DESCRIPTION
This patch-set adds support for all possible stablelist headers to date.
Legacy terminology is removed from comments and/or kabi-dw output.

Tested on handful of valid/invalid input strings. Tests attached below.

# Testing

## Test outcome

```
[kabi_stablelist]              PASSED (input is valid)
[kabi_whitelist]               PASSED (input is valid)
[kabi_stable1list]             PASSED (input is invalid)
kabi_whitelist]                PASSED (input is invalid)
kabi_whitelist                 PASSED (input is invalid)
__EMPTY__                      PASSED (input is invalid)
kabi_stablelist]               PASSED (input is invalid)
kabi_stablelist                PASSED (input is invalid)
[kabi_whitelist                PASSED (input is invalid)
[kabi_greylist]                PASSED (input is invalid)
```

## Tests

```sh
#!/usr/bin/env bash

declare -A TESTS
TESTS["[kabi_stablelist]"]=1
TESTS["[kabi_whitelist]"]=1

TESTS["__EMPTY__"]=0

TESTS["kabi_stablelist]"]=0
TESTS["kabi_whitelist]"]=0
TESTS["kabi_stablelist"]=0
TESTS["[kabi_whitelist"]=0
TESTS["kabi_stablelist"]=0
TESTS["kabi_whitelist"]=0

TESTS["[kabi_greylist]"]=0
TESTS["[kabi_stable1list]"]=0

TEST_CASE=${TEST_CASE:-test.c}

if ! gcc -Wall -Werror -Wextra -pedantic --std=gnu99 -D_GNU_SOURCE \
        ${TEST_CASE} -o ./test
then
        exit 3
fi

for str in "${!TESTS[@]}"
do
        ./test "${str//__EMPTY__/}"
        res="$?"

        if [ $res -eq 2 ]
        then
                res="TEST FAILURE"
        else
                if [ $res -eq ${TESTS[$str]} ]
                then
                        res="PASSED"
                        [ ${TESTS[$str]} -eq 1 ] \
                                && res+=" (input is valid)" \
                                || res+=" (input is invalid)"
                else
                        res="FAILED (got $res != ${TESTS[$str]} expected)"
                fi
        fi

        printf "%-30s %s\n" "$str" "$res"
done
```

```c
#include <assert.h>
#include <stdbool.h>
#include <string.h>

static bool is_kabi_header(char *s)
{
        const char *suffixes[2] = {
                "_whitelist]",
                "_stablelist]"
        };

        int suffixlen;
        int len;
        size_t i;

        assert(s != NULL);
        len = strlen(s);

        for (i = 0; i < sizeof(suffixes)/sizeof(suffixes[0]); ++i) {
                suffixlen = strlen(suffixes[i]);

                if (len <= suffixlen + 1)
                        continue;

                if (s[0] != '[')
                        continue;

                if (strcmp(s + (len - suffixlen), suffixes[i]) != 0)
                        continue;

                return true;
        }

        return false;
}

int main(int argc, char **argv)
{
        return (argc < 2) ? 2 : is_kabi_header(argv[1]);
}
```