### PR TITLE
Add symbol namespace support

### DIFF
--- a/ksymtab.h
+++ b/ksymtab.h
@@ -35,6 +35,7 @@ struct ksym {
 	bool mark;
 	char *link;
 	struct ksymtab *ksymtab;
+	char *ns;
 	char key[];
 };
 

--- a/objects.c
+++ b/objects.c
@@ -95,6 +95,7 @@ obj_t *obj_new(obj_types type, char *name)
 
 	new->type = type;
 	new->name = global_string_get_move(name);
+	new->ns = NULL;
 
 	return new;
 }
@@ -1031,6 +1032,7 @@ bool obj_eq(obj_t *o1, obj_t *o2, bool ignore_versions)
 	    (has_index(o1) && (o1->index != o2->index)) ||
 	    (is_bitfield(o1) != is_bitfield(o2)) ||
 	    (o1->alignment != o2->alignment) ||
+	    !safe_streq(o1->ns, o2->ns) ||
 	    (o1->byte_size != o2->byte_size))
 		return false;
 

--- a/objects.h
+++ b/objects.h
@@ -122,6 +122,7 @@ typedef struct obj {
 		unsigned long offset;
 		struct list_node *depend_rec_node;
 	};
+	char *ns;
 } obj_t;
 
 static inline bool has_offset(obj_t *o)

--- a/parser.l
+++ b/parser.l
@@ -69,6 +69,10 @@ HEX		[a-fA-F0-9]
 				  return(SRCFILE);
 				}
 
+^"Namespace"     { debug("Namespace\n");
+		   return(NAMESPACE);
+		 }
+
 {IDENT_FIRST}{IDENT}*	{ yylval.str = strdup(yytext);
 			  debug("Identifier: %s\n", yylval.str);
 			  return(IDENTIFIER);

--- a/parser.y
+++ b/parser.y
@@ -58,6 +58,7 @@
 %token STRUCT UNION ENUM ELLIPSIS
 %token VERSION_KW CU_KW FILE_KW STACK_KW SYMBOL_KW_NL
 %token ARROW UNKNOWN_FIELD
+%token NAMESPACE
 
 %type <str> type_qualifier
 %type <obj> typed_type base_type reference_file array_type
@@ -68,6 +69,7 @@
 %type <obj> asm_symbol weak_symbol
 %type <list> elt_list arg_list enum_list struct_list
 %type <ul> alignment byte_size
+%type <str> namespace
 
 %parse-param {obj_t **root}
 
@@ -142,6 +144,17 @@ symbol:
 		$$ = $declaration;
 		$$->alignment = $alignment;
 	}
+	| alignment namespace declaration NEWLINE
+	{
+		$$ = $declaration;
+		$$->alignment = $alignment;
+		$$->ns = $namespace;
+	}
+	| namespace declaration NEWLINE
+	{
+		$$ = $declaration;
+		$$->ns = $namespace;
+	}
 	| byte_size declaration NEWLINE
 	{
 		$$ = $declaration;
@@ -152,6 +165,19 @@ symbol:
 		$$ = $declaration;
 		$$->byte_size = $byte_size;
 		$$->alignment = $alignment;
+	}
+	| byte_size namespace declaration NEWLINE
+	{
+		$$ = $declaration;
+		$$->byte_size = $byte_size;
+		$$->ns = $namespace;
+	}
+	| byte_size alignment namespace declaration NEWLINE
+	{
+		$$ = $declaration;
+		$$->byte_size = $byte_size;
+		$$->alignment = $alignment;
+		$$->ns = $namespace;
 	}
 
 alignment:
@@ -167,6 +193,12 @@ byte_size:
 		check_and_free_keyword($1, "Byte");
 		check_and_free_keyword($2, "size");
 		$$ = $CONSTANT;
+	}
+
+namespace:
+        NAMESPACE IDENTIFIER NEWLINE
+	{
+		$$ = $IDENTIFIER;
 	}
 
 /* Possible types are struct union enum func typedef and var */


### PR DESCRIPTION
# Description

Symbol namespaces have been introduced as means to structure the export surface of the in-kernel API. For more information, see [Documentation/core-api/symbol-namespaces.rst](https://www.kernel.org/doc/html/latest/core-api/symbol-namespaces.html).

 - Include symbol namespace in exported symbol generate output such as
```
Symbol:
Byte size 20
Namespace BAR
var foo [5]"int"
```
 - Previous kabi-dw versions would emit a set of false positive assembly records corresponding to symbol namespaces when used on kernel modules built with symbol namespace support, e.g., `asm--BAR.txt`
```
Symbol:
assembly BAR
```
where `BAR` is an example of such symbol namespace. The patchset removes these false positive records.

 - Support parsing and comparing symbol namespace information of exported symbols as generated by kabi-dw generate.

# Testing

The following test case was used:

Test kernel module used:
```c
#include <linux/module.h>
#include <linux/kernel.h>

MODULE_LICENSE("GPL");
MODULE_DESCRIPTION("Description");
MODULE_AUTHOR("Unnamed");

int init_module(void)
{
        printk(KERN_INFO "Module loaded.\n");
        return 0;
}

void cleanup_module(void)
{
        printk(KERN_INFO "Module unloaded.\n");
}

#define GENERATE_FN(T, fnName, macro, ...) \
        T * fnName(__VA_ARGS__) \
        { \
                printk(KERN_INFO "#fnName\n"); \
                return NULL; \
        } \
        macro(fnName);

#define GENERATE_FN_NS(T, fnName, ns, macro, ...) \
        T * fnName(__VA_ARGS__) \
        { \
                printk(KERN_INFO "#fnName\n"); \
                return NULL; \
        } \
        macro(fnName, ns)

#define GENERATE_GLOB(T, name, macro) \
        extern T name; \
        T name = {}; \
        macro(name);

#define GENERATE_GLOB_NS(T, name, ns, macro) \
        extern T name; \
        T name = {}; \
        macro(name, ns);

#if defined(EXPORT_SYMBOL_NS) && defined(USE_NS)
# define EXPORT_SYMBOL_NS_SAFE(x,y) EXPORT_SYMBOL_NS(x,y)
#else
# define EXPORT_SYMBOL_NS_SAFE(x,y) EXPORT_SYMBOL(x)
#endif

typedef struct S_A8 {
#ifndef S_A8_1
        u64 a : 1;
#endif
#ifndef S_A8_2
        short b[3];
#endif
#ifndef S_A8_3
        int c : 1;
#endif
} __attribute__ ((aligned (8))) S_A8_t;

typedef struct S_A8_P {
#ifndef S_A8_P_1
        int a : 1;
#endif
#ifndef S_A8_P_2
        short b[3];
#endif
#ifndef S_A8_P_3
        int c : 1;
#endif
} __attribute__ ((aligned (8), packed)) S_A8_P_t;

typedef struct S_U {
#ifndef S_U_1
        union {
#ifndef S_U_1_1
                volatile struct S_A8 s1;
#endif
#ifndef S_U_1_2
                struct S_A8_P * s2[20];
#endif
        } u[5];
#endif
#ifndef S_U_1
        volatile struct S_A8 ** (*ptr)(const volatile S_A8_t *, const struct S_A8_P * const);
#endif
} S_U_t;

#if defined(EXPORT_SYMBOL_NS) && defined(USE_NS)
# ifndef NS1
#  error "-DNS1=ns"
# endif

# ifndef NS2
#  error "-DNS2=ns"
# endif

# ifndef NS3
#  error "-DNS3=ns"
# endif

# ifndef NS4
#  error "-DNS4=ns"
# endif

GENERATE_GLOB_NS(struct S_A8, s_a8, NS1, EXPORT_SYMBOL_NS_SAFE);
GENERATE_GLOB_NS(struct S_A8_P, s_a8_p, NS2, EXPORT_SYMBOL_NS_SAFE);
GENERATE_GLOB_NS(struct S_U, s_u, NS3, EXPORT_SYMBOL_NS_SAFE);

GENERATE_GLOB_NS(S_A8_t, s_a8_t, NS1, EXPORT_SYMBOL_NS_SAFE);
GENERATE_GLOB_NS(S_A8_P_t, s_a8_p_t, NS2, EXPORT_SYMBOL_NS_SAFE);
GENERATE_GLOB_NS(S_U_t, s_u_t, NS3, EXPORT_SYMBOL_NS_SAFE);
GENERATE_FN_NS(const struct S_A8 *, fn1, NS4, EXPORT_SYMBOL_NS_SAFE, volatile struct S_A8_P **a, const S_U_t * const b);
#endif

GENERATE_GLOB(struct S_A8, s_a8_no_ns, EXPORT_SYMBOL);
GENERATE_GLOB(struct S_A8_P, s_a8_p_no_ns, EXPORT_SYMBOL);
GENERATE_GLOB(struct S_U, s_u_no_ns, EXPORT_SYMBOL);

GENERATE_GLOB(S_A8_t, s_a8_tno_ns, EXPORT_SYMBOL);
GENERATE_GLOB(S_A8_P_t, s_a8_p_tno_ns, EXPORT_SYMBOL);
GENERATE_GLOB(S_U_t, s_u_t_no_ns, EXPORT_SYMBOL);
GENERATE_FN(const struct S_A8 *, fn1_no_ns, EXPORT_SYMBOL, volatile struct S_A8_P **a, const S_U_t * const b);
```

```make
obj-m += kmod.o
ccflags-y += $(CFLAGS)
OUT ?= kmod.ko

all:
        make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
        mv kmod.ko $(OUT) &> /dev/null || :

clean:
        make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
```

Built in 3 variants: symbol namespace support baseline (`1.ko`), an ABI breakage w.r.t. baseline (`2.ko`), and namespace change w.r.t. to baseline (`3.ko`).
```sh
make CFLAGS="-DUSE_NS -DNS1=ns1 -DNS2=ns2 -DNS3=ns3 -DNS4=ns4" OUT="1.ko" clean all
make CFLAGS="-DUSE_NS -DNS1=ns1 -DNS2=ns2 -DNS3=ns3 -DNS4=ns4 -DS_A8_1 -DS_A8_P_1" OUT="2.ko"  all
make CFLAGS="-DUSE_NS -DNS1=ns1 -DNS2=ns22 -DNS3=ns3 -DNS4=ns4 
```

```sh
for i in ../kmod-ns/{1,2,3}.ko; do rm -rf out-`basename $i`; ./kabi-dw generate -o out-`basename $i` $i; done
```

Output remains the same when tested on symbol namespace unrelated changes.

```
$ diff <(../kabi-dw-pre-patchset/kabi-dw compare ../kabi-dw-pre-patchset/out-{1,2}.ko/) <(./kabi-dw compare ./out-{1,2}.ko/)
```

Symbol namespace changes are presented as follows:

```
./kabi-dw compare ./out-{2,3}.ko/
Changes detected in: var--s_a8_p.txt
The namespace of symbol 's_a8_p' has changed from ns2 to ns22

Changes detected in: var--s_a8_p_t.txt
The namespace of symbol 's_a8_p_t' has changed from ns2 to ns22
```

# Related Issues

Resolves https://github.com/skozina/kabi-dw/issues/15