### PR TITLE
dwarf: add support for DW_TAG_restrict_type

### DIFF
--- a/generate.c
+++ b/generate.c
@@ -1832,6 +1832,11 @@ static obj_t *print_die_tag(struct cu_ctx *ctx,
 	case DW_TAG_array_type:
 		obj = print_die_array_type(ctx, rec, die);
 		break;
+	case DW_TAG_restrict_type:
+		obj = print_die_type(ctx, rec, die);
+		obj = obj_qualifier_new_add(obj);
+		obj->base_type = global_string_get_copy("restrict");
+		break;
 	default: {
 		const char *tagname = dwarf_tag_string(tag);
 		if (tagname == NULL)

--- a/parser.l
+++ b/parser.l
@@ -42,6 +42,7 @@ HEX		[a-fA-F0-9]
 "typedef"	{ return(TYPEDEF); }
 "union"		{ return(UNION); }
 "volatile"	{ return(VOLATILE); }
+"restrict"	{ return(RESTRICT); }
 
 "..."		{ return(ELLIPSIS); }
 }

--- a/parser.y
+++ b/parser.y
@@ -54,7 +54,7 @@
 
 %token NEWLINE
 %token TYPEDEF
-%token CONST VOLATILE
+%token CONST VOLATILE RESTRICT
 %token STRUCT UNION ENUM ELLIPSIS
 %token VERSION_KW CU_KW FILE_KW STACK_KW SYMBOL_KW_NL
 %token ARROW UNKNOWN_FIELD
@@ -435,6 +435,11 @@ type_qualifier:
 	{
 	    debug("Qualifier: volatile\n");
 	    $$ = strdup("volatile");
+	}
+	| RESTRICT
+	{
+	    debug("Qualifier: restrict\n");
+	    $$ = strdup("restrict");
 	}
 	;
 


### PR DESCRIPTION
Decl statements containing a restrict keyword such as

	volatile char * const restrict p;

raise

	print_die_tag():1827 Unexpected tag for symbol (null): restrict_type

when `DW_TAG_restrict_type` is emitted, failing the output generation.

Add support for their generating and parsing. Treat it like any other
qualifier and emit, e.g., for `stpcpy`
```
Symbol:
func stpcpy (
dest restrict * "char"
src restrict * const "char"
)
* "char"
```
Signed-off-by: Čestmír Kalina <ckalina@redhat.com>