### PR TITLE
Makefile: release build: pie, bind-now, fortify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,10 @@ CC?=gcc
 CFLAGS+=-Wall --std=gnu99 -D_GNU_SOURCE -c
 LDFLAGS+=-ldw -lelf
 
-CFLAGS_RELEASE+=-O2
+CFLAGS_RELEASE+=-O2 -Wl,-pie -D_FORTIFY_SOURCE=2
 CFLAGS_DEBUG+=-O0 -g3 -DDEBUG -Wextra -pedantic
+
+LDFLAGS_RELEASE+=-Wl,-z,now
 
 YACC=bison
 YACCFLAGS=-d -t
@@ -52,6 +54,7 @@ override LDFLAGS+=-lelf
 endif
 
 all: CFLAGS+=$(CFLAGS_RELEASE)
+all: LDFLAGS+=$(LDFLAGS_RELEASE)
 all: $(PROG)
 
 debug: CFLAGS+=$(CFLAGS_DEBUG)

--- a/generate.c
+++ b/generate.c
@@ -118,7 +118,7 @@ static void obj_fill_ns(obj_t *obj, struct cu_ctx *ctx, const char *name)
 	struct ksym *ksym;
 
 	if ((ksym = ksymtab_find(ctx->ksymtab, name)) != NULL && ksym->ns) {
-		asprintf(&obj->ns, "%s", ksym->ns);
+		safe_asprintf(&obj->ns, "%s", ksym->ns);
 	}
 }
 

--- a/ksymtab.c
+++ b/ksymtab.c
@@ -435,7 +435,7 @@ static void ns_filter(const char *name, uint64_t value, int bind, void *_ctx)
 	if (!(ksym = hash_find(ctx->ksymtab->hash, name)))
 		return;
 
-	asprintf(&ksym->ns, "%s", ns);
+	safe_asprintf(&ksym->ns, "%s", ns);
 
 	if (!(ksym = hash_find(ctx->ksymtab->hash, ns)))
 		return;


### PR DESCRIPTION
```
CFLAGS += -Wl,-pie -D_FORTIFY_SOURCE=2
FDFLAGS += -Wl,-z,now
```

Replace `asprintf` by `safe_asprintf`.

Signed-off-by: Čestmír Kalina <ckalina@redhat.com>