### PR TITLE
generate: add support DW_TAG_unspecified_type

### DIFF
--- a/generate.c
+++ b/generate.c
@@ -1796,6 +1796,9 @@ static obj_t *print_die_tag(struct cu_ctx *ctx,
 		obj = obj_var_new_add(safe_strdup(name), obj);
 		obj_fill_ns(obj, ctx, obj->name);
 		break;
+	case DW_TAG_unspecified_type:
+		obj = obj_basetype_new(safe_strdup("auto"));
+		break;
 	case DW_TAG_base_type:
 		obj = obj_basetype_new(safe_strdup(name));
 		break;


### PR DESCRIPTION
GAS 2.40 and later add return type tag to DWARF DIEs generated for function symbols, introduced in [1]

    commit 5578fbf672ee497ea19826edeb509f4cc3e825a8
    Author: Nick Clifton <nickc@redhat.com>
    Date:   Thu Aug 25 11:48:00 2022 +0100

        GAS: Add a return type tag to DWARF DIEs generated for function symbols.

This is compliant with the DWARFv5 stardard [2], Sec. 3.3.2 and Sec. 5.2. The resulting DW_TAG_subprogram then has a DW_AT_type attribute pointing to a DW_TAG_unspecified_type. For example,

    arch/x86/entry/entry.S:
        SYM_FUNC_START(entry_ibpb)
        ...
        RET
        SYM_FUNC_END(entry_ibpb)
        EXPORT_SYMBOL_GPL(entry_ibpb);

emits

    DW_TAG_subprogram
        DW_AT_name      ("entry_ibpb")
        DW_AT_external  (true)
        DW_AT_type      (0x12345678 "") -

    0x12345678:   DW_TAG_unspecified_type

As is, when processing DW_TAG_subprogram (print_die_subprogram), kabi-dw calls print_die_tag to determine the return type and fail on an unsupported DW_TAG:

    print_die_tag():1845 Unexpected tag for symbol (null): 3b (unspecified_type)
    Generating symbol defs from kernel-6.12.0-42.el10.x86_64/vmlinux

This commit adds a new DW_TAG_unspecified_type case to said function's processing and treats it as a new "basetype" named "auto".

This corresponds to the following file func--entry_ibpb.txt:

    Symbol:
    func entry_ibpb (
    )
    "auto"

[1] https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=5578fbf672ee497ea19826edeb509f4cc3e825a8

[2] https://dwarfstd.org/doc/DWARF5.pdf

---

`unspecified` was also considered, but `auto` might be more suggestive in that it is a keyword in other languages, [might](https://www.open-std.org/JTC1/SC22/WG14/www/docs/n3007.htm) become a reserved C keyword, and (not that it's relevant) C++ emits the same tag for its auto return values; but I am certainly open to better naming suggestions...